### PR TITLE
Allow matching endpoint token by query

### DIFF
--- a/lib/jwt/endpoint_token.rb
+++ b/lib/jwt/endpoint_token.rb
@@ -23,5 +23,11 @@ module JWT
     claim :verb, required: true do |value, rack_req|
       raise JWT::DecodeError, "Unexpected request method: #{value}" unless value.to_s.upcase == rack_req.request_method
     end
+
+    claim :query, required: false do |value, rack_req|
+      unless  Rack::Utils.parse_nested_query(value) == rack_req.params.delete_if { |k, _v| k == "_t" }
+        raise JWT::DecodeError, "Unexpected query parameters: #{value}"
+      end
+    end
   end
 end


### PR DESCRIPTION
It should be possible to define query parameters in token. For example we would like to allow `GET` all users with the name `Piotr`. The URL would look like `{...}/users?name=Piotr` but the `path` would be `{...}/users`. So in that example person with our token would access all users, not only those ones with the Piotr name.